### PR TITLE
Update CI

### DIFF
--- a/project/.github/workflows/build_and_test.yml.jinja
+++ b/project/.github/workflows/build_and_test.yml.jinja
@@ -2,11 +2,14 @@ name: CI (build and test)
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
     tags:
-      - "*"
+      - "v*"
   pull_request:
-    branches: ["main"]
+  workflow_dispatch:
+  release:
+    types: [published]
 
 
 jobs:

--- a/project/.github/workflows/build_and_test.yml.jinja
+++ b/project/.github/workflows/build_and_test.yml.jinja
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "v*"
+      - "*"
   pull_request:
   workflow_dispatch:
   release:


### PR DESCRIPTION
This minor change updates the CI so that it also runs on releases. That enables the workflow where someone makes a Github release (directly on the website) & the CI then adds the whls to that release