### PR TITLE
Run `zizmor` scan of GitHub actions

### DIFF
--- a/.github/workflows/copy-install-test-build.yml
+++ b/.github/workflows/copy-install-test-build.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install copier
         run: pipx install copier

--- a/.github/workflows/github_release.yaml
+++ b/.github/workflows/github_release.yaml
@@ -14,5 +14,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/project/.github/workflows/build_and_test.yml.jinja
+++ b/project/.github/workflows/build_and_test.yml.jinja
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Python ${{ '{{' }} matrix.python-version {{ '}}' }}
         uses: actions/setup-python@v5
@@ -73,6 +74,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
I am ignoring the following warning
```
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> [...]/fractal-tasks-template/project/.github/workflows/build_and_test.yml.jinja:3:1
   |
 3 | / on:
 4 | |   push:
...  |
11 | |   release:
12 | |     types: [published]
   | |______________________^ generally used when publishing artifacts generated at runtime
13 |
...
37 |           uses: actions/setup-python@v5
38 | /         with:
39 | |           python-version: ${{ '{{' }} matrix.python-version {{ '}}' }}
40 | |           cache: "pip"
   | |______________________^ opt-in for caching here
   |
   = note: audit confidence → Low
```
because the cache is used for testing, while the deployment part is a different GitHub action job.